### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -1,5 +1,8 @@
 name: Update Tag on VERSION Change
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/wnc/security/code-scanning/2](https://github.com/umatare5/wnc/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions. Since the workflow needs to push tags, it requires `contents: write` permission. This will ensure that the workflow has only the necessary permissions and adheres to the principle of least privilege.

The `permissions` block will be added at the top level of the workflow, applying to all jobs within the workflow. No other changes to the workflow are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
