### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,4 +1,6 @@
 name: Lint Code with golangci-lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/wnc/security/code-scanning/1](https://github.com/umatare5/wnc/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a linting workflow that only checks out code and runs analysis, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. 

**Steps:**
- Add a `permissions:` block at the top level of the workflow file, just after the `name:` and before the `on:` block.
- Set `contents: read` as the minimal required permission.

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
